### PR TITLE
Added .gitattributes to declare Github syntax highlighting for mvt files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Declare Github syntax highlighting for .mvt files
+# https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
+*.mvt linguist-language=XML


### PR DESCRIPTION
[More information about github-linguist](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md)